### PR TITLE
fix: Keep video tracks first

### DIFF
--- a/dovi_tool/entrypoint.sh
+++ b/dovi_tool/entrypoint.sh
@@ -82,9 +82,9 @@ demux_file() {
 remux_file() {
 	echo "Remuxing $1..."
 	echo "------------------"
-	echo "mkvmerge -o ${1%.*}.mkv.tmp -D $1 BL_RPU.hevc"
+	echo "mkvmerge -o ${1%.*}.mkv.tmp BL_RPU.hevc -D $1"
 	echo "------------------"
-	if ! mkvmerge -o "${1%.*}.mkv.tmp" -D "$1" BL_RPU.hevc; then
+	if ! mkvmerge -o "${1%.*}.mkv.tmp" BL_RPU.hevc -D "$1"; then
 		echo "Failed to remux $1"
 		cleanup "$1"
 		exit 1


### PR DESCRIPTION
## Description

Thanks for putting the `dovi_tool` Docker image together. It's convenient and works well.

This PR proposes a small change to the remux step.

When MakeMKV produces a file, the video track is typically first (track 0), followed by audio tracks, followed by subtitle tracks.

The `mkvmerge` remux step in `entrypoint.sh` reverses this order.

https://github.com/riweston/fileflows/blob/32cd5e267574339fe961c15c14445cefd5091aba/dovi_tool/entrypoint.sh#L87

Unless the `--track-order` option is given, `mkvmerge` combines files in left-to-right order. This means that, with the current command, audio and subtitle tracks are first and video tracks are last. This can result in unexpected track selections if users are doing further prop edits or remuxes and don't carefully evaluate the file with `mkvinfo` beforehand.

## Changes

This PR fixes the order of files passed to `mkvmerge` so the video track will remain track 0 in the remuxed file.

## Related

- [`dovi_tool`](https://github.com/quietvoid/dovi_tool)
- [`mkvtoolnix` docs](https://mkvtoolnix.download/doc/mkvmerge.html)
