### PR TITLE
Update dovi_tool config to keep CMV4

### DIFF
--- a/dovi_tool/dovi_tool.config.json
+++ b/dovi_tool/dovi_tool.config.json
@@ -1,5 +1,5 @@
 {
     "mode": 2,
-    "remove_cmv4": true,
+    "remove_cmv4": false,
     "remove_mapping": true
 }


### PR DESCRIPTION
The new version of Infuse handles CMV4 properly, so no need to strip it out anymore.